### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hobeone/envoy-exporter/security/code-scanning/2](https://github.com/hobeone/envoy-exporter/security/code-scanning/2)

The recommended fix is to add a `permissions:` block setting `contents: read` (the minimal permission usually required to access repository code) at the top workflow level—immediately below or above the `on:` key, and above `jobs:`. This ensures that all jobs within the workflow, unless overridden, receive only those permissions. No steps in the shown workflow require any write permissions, so this change will not alter behavior or break functionality.

**Detailed steps:**
- Insert a `permissions:` block after the `name: Go` line (line 4) and before the `on:` key (line 6) to globally set minimal required permissions.
- The YAML would read:

```yaml
name: Go
permissions:
  contents: read

on:
  push:
    branches: [ "main" ]
  ...
```

No imports, library changes, or other code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
